### PR TITLE
Android plural suffixes

### DIFF
--- a/lib/android_formatter.rb
+++ b/lib/android_formatter.rb
@@ -40,7 +40,9 @@ module Poesie
             term.gsub!('.', '_')
             plurals.gsub!('.', '_')
             
+            # _android suffix should be removed from all terms
             term.gsub!('_android', '')
+            plurals.gsub!('_android', '')
 
             xml_builder.comment!(context) unless context.empty?
             if plurals.empty?

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Poesie
-  VERSION = '1.5.4'
+  VERSION = '1.5.5'
 end


### PR DESCRIPTION
Discovered that we only replace the _android suffix from string terms but not the plural terms. So I fixed those as well. Already tested